### PR TITLE
fix: set an explicit scheduler partition in preflight

### DIFF
--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -88,7 +88,8 @@
         "runtime": 120,
         "storage": "1G",
         "policy_data": {
-            "gpu_count": 0
+            "gpu_count": 0,
+            "partition": "gpu2"
         }
     }
 }

--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -89,7 +89,7 @@
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "gpu2"
+            "partition": "compute"
         }
     }
 }

--- a/docs/HANDOFF_DEPLOYMENT_TEAM.md
+++ b/docs/HANDOFF_DEPLOYMENT_TEAM.md
@@ -69,7 +69,7 @@ Based on actual benchmarks (see [RUNTIME_METRICS.md](RUNTIME_METRICS.md)):
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "normal"
+            "partition": "gpu2"
         }
     }
 }

--- a/docs/HANDOFF_DEPLOYMENT_TEAM.md
+++ b/docs/HANDOFF_DEPLOYMENT_TEAM.md
@@ -69,7 +69,7 @@ Based on actual benchmarks (see [RUNTIME_METRICS.md](RUNTIME_METRICS.md)):
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "gpu2"
+            "partition": "compute"
         }
     }
 }

--- a/docs/adr/0001-stabilinnator-bvbrc-module-design.md
+++ b/docs/adr/0001-stabilinnator-bvbrc-module-design.md
@@ -47,6 +47,14 @@ startup overhead is counted. The app therefore treats GPU as optional
 - **Consequence:** the preflight must not demand a GPU partition; jobs schedule
   on CPU nodes by default.
 
+- **Amended 2026-08-22:** the consequence above no longer holds. The app is now
+  deployed in the shared ProteinPrediction container, which is only available on
+  the GPU partitions, so preflight requests `partition: gpu2`. This is a
+  placement constraint imposed by where the container exists, not a reversal of
+  the decision above: inference still runs on CPU by default and preflight still
+  requests `gpu_count: 0`. The reasoning about GPU being optional for *compute*
+  stands.
+
 ### 3. Preflight resource requests are driven by measured benchmarks
 
 Rather than guess CPU/memory/runtime, Phase 1 captured runtime metrics across

--- a/docs/adr/0001-stabilinnator-bvbrc-module-design.md
+++ b/docs/adr/0001-stabilinnator-bvbrc-module-design.md
@@ -47,13 +47,15 @@ startup overhead is counted. The app therefore treats GPU as optional
 - **Consequence:** the preflight must not demand a GPU partition; jobs schedule
   on CPU nodes by default.
 
-- **Amended 2026-08-22:** the consequence above no longer holds. The app is now
-  deployed in the shared ProteinPrediction container, which is only available on
-  the GPU partitions, so preflight requests `partition: gpu2`. This is a
+- **Amended 2026-08-22:** the consequence above is now qualified. The app is
+  deployed in the shared ProteinPrediction container and must be scheduled where
+  that container is available, so preflight names an explicit partition
+  (currently `compute`) rather than leaving placement to the default. This is a
   placement constraint imposed by where the container exists, not a reversal of
   the decision above: inference still runs on CPU by default and preflight still
   requests `gpu_count: 0`. The reasoning about GPU being optional for *compute*
-  stands.
+  stands. If the container turns out not to be hosted on `compute`, the
+  partition moves to `gpu2`.
 
 ### 3. Preflight resource requests are driven by measured benchmarks
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -105,7 +105,11 @@ sub preflight {
         storage => $storage,
         policy_data => {
             gpu_count => $gpu_count,
-            partition => 'normal',  # Always use normal partition (CPU is faster)
+            # Placement constraint, not a compute choice: this app is deployed in
+            # the ProteinPrediction container, which is only available on the GPU
+            # partitions. We still run inference on CPU by default (faster for
+            # these small models), hence gpu_count => 0 on a gpu partition.
+            partition => 'gpu2',
         }
     };
 }

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -105,11 +105,12 @@ sub preflight {
         storage => $storage,
         policy_data => {
             gpu_count => $gpu_count,
-            # Placement constraint, not a compute choice: this app is deployed in
-            # the ProteinPrediction container, which is only available on the GPU
-            # partitions. We still run inference on CPU by default (faster for
-            # these small models), hence gpu_count => 0 on a gpu partition.
-            partition => 'gpu2',
+            # Placement constraint, not a compute choice: this app is deployed
+            # in the shared ProteinPrediction container and must be scheduled
+            # where that container is available. Inference still runs on CPU by
+            # default (faster for these small models), hence gpu_count => 0.
+            # If 'compute' turns out not to host the container, switch to 'gpu2'.
+            partition => 'compute',
         }
     };
 }


### PR DESCRIPTION
## Summary

Preflight requested the `normal` partition, but this app is deployed in the shared **ProteinPrediction** container and must be scheduled where that container is available. A scheduler-submitted job could otherwise be placed where its container does not exist.

Preflight now names an explicit partition — **`compute`** — and the three other places that still encoded `normal` are aligned with it.

`gpu_count` stays `0` unless the user explicitly requests `accelerator=gpu`; inference still runs on CPU by default (faster for these small models). The partition is a **placement constraint**, not a compute choice; a comment records this so it does not read as a bug.

> **Note:** `compute` is the first choice. If the ProteinPrediction container turns out not to be hosted on that partition, this moves to `gpu2` — the code comment and ADR amendment both record that fallback.

## Commits

- `a078236` — preflight callback in `service-scripts/App-StabiliNNator.pl`
- `d109225` — follow-up from code review, covering three spots that still said `normal`:
  - `app_specs/StabiliNNator.json` — spec-declared preflight block had no `partition` key, so any fallback to the static block would reintroduce the bug
  - `docs/HANDOFF_DEPLOYMENT_TEAM.md` — prescribed `"partition": "normal"` verbatim
  - `docs/adr/0001` — amended (not rewritten) the superseded consequence; the underlying "GPU optional for compute" reasoning still holds, only the placement consequence changed
- `d9e4a32` — switch the chosen partition from `gpu2` to `compute` across all four files

## Verification

Run through the real `AppScript` preflight path inside `folding_260821.1.sif` (rc=0 both cases):

| analysis_type | cpu | memory | runtime | partition | gpu_count |
|---|---|---|---|---|---|
| `both` | 2 | 1G | 120 | `compute` | 0 |
| `proline` | 2 | 1G | 60 | `compute` | 0 |

Earlier in the same container, the full job body was also confirmed end-to-end against the live BV-BRC workspace (download → proliNNator → disulfiNNate → summaries → HTML report → upload, exit 0).

## Note for deployment

This only takes effect once a new container is built from these sources — the copy inside `folding_260821.1.sif` still has `partition => 'normal'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
