### PR TITLE
fix: schedule on gpu2 and allow 10 minutes for container staging

### DIFF
--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -85,11 +85,11 @@
     "preflight": {
         "cpu": 2,
         "memory": "1G",
-        "runtime": 120,
+        "runtime": 600,
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "compute"
+            "partition": "gpu2"
         }
     }
 }

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -71,14 +71,25 @@ sub preflight {
 
     my $cpu = 2;           # Sufficient for GNN inference
     my $memory = "1G";     # Benchmarked at ~500MB, 1G provides buffer
-    my $runtime = 30;      # Base: container startup + model loading
     my $storage = "1G";    # Output PDBs are small
+
+    # Runtime is dominated by CONTAINER STAGING, not by inference. The shared
+    # ProteinPrediction image is ~27 GB; a node that does not already have it
+    # cached pulls it at ~130 MB/s, i.e. ~3 minutes. The previous 120s
+    # allowance could not absorb that: tasks 23450798-23450800 were dispatched,
+    # spent their whole walltime staging, and were killed with no output at
+    # all (2:12, 1:09, 1:05 elapsed, empty stdout/stderr, no task_status dir).
+    # Inference itself is sub-second; 10 minutes is staging headroom.
+    my $runtime = 600;
 
     # Adjust based on analysis type
     my $analysis_type = $params->{analysis_type} // 'both';
 
+    # Both analyses take ~12s of actual compute; the difference is noise
+    # against staging, so the single 600s allowance covers every analysis
+    # type. Kept explicit so the intent is not mistaken for an oversight.
     if ($analysis_type eq 'both') {
-        $runtime = 60;     # Both analyses: ~12s actual, 60s with buffer
+        $runtime = 600;
     }
 
     # Note: GPU mode is NOT recommended for stabiliNNator
@@ -93,10 +104,9 @@ sub preflight {
         # Keep same runtime (don't reduce)
     }
 
-    # For very large proteins (>1000 residues), disulfiNNate has O(n²) scaling
-    # Add buffer for edge computation: 1AON (8,015 residues) took 18.6s
-    # Without knowing protein size at preflight, use conservative estimate
-    $runtime = $runtime * 2;  # 2x buffer for safety
+    # For very large proteins (>1000 residues), disulfiNNate has O(n²) scaling.
+    # 1AON (8,015 residues) took 18.6s -- still negligible beside staging, and
+    # 600s already carries a large margin, so no additional multiplier.
 
     return {
         cpu => $cpu,
@@ -109,8 +119,12 @@ sub preflight {
             # in the shared ProteinPrediction container and must be scheduled
             # where that container is available. Inference still runs on CPU by
             # default (faster for these small models), hence gpu_count => 0.
-            # If 'compute' turns out not to host the container, switch to 'gpu2'.
-            partition => 'compute',
+            #
+            # 'compute' was tried first and the jobs did dispatch, but then died
+            # with no output (tasks 23450798-23450800) -- those nodes do not
+            # carry the ~27 GB image. gpu2 nodes demonstrably do: every
+            # PredictStructure job runs there from cache. Verified 2026-08-24.
+            partition => 'gpu2',
         }
     };
 }


### PR DESCRIPTION
Follow-up to #16. That change (`compute`) fixed **dispatch** — the scheduler now accepts and places the jobs — but they still fail, at a later stage and with a different signature.

| | `normal` (pre-#16) | `compute` (#16) | this PR |
|---|---|---|---|
| start_time | none | 21:19:43 | — |
| elapsed | none | 2:12 / 1:09 / 1:05 | — |
| outcome | refused, never ran | dispatched, ran, killed | expected pass |

Tasks 23450798-23450800 produced **empty stdout/stderr and no `task_status` directory**, i.e. the container never started. Two compounding causes:

**1. `compute` nodes do not carry the image.** The shared ProteinPrediction container is ~27 GB; gpu2 nodes have it cached (every PredictStructure job runs from there), compute nodes would have to pull it. Switching to `gpu2` sidesteps staging entirely. `gpu_count` stays **0** — inference is still CPU-only, this is placement, exactly as #16 framed it.

**2. `runtime => 120` cannot absorb a cold stage.** A 27 GB pull at the ~130 MB/s measured on this cluster is ~3 minutes. S01 died at **2:12** against a 120s allowance — that is a walltime kill, not a crash. Raised to 600s. Inference stays sub-second, so the per-analysis-type branch and the 2x safety multiplier are folded into one allowance rather than layered on top.

Both copies are updated — `App-StabiliNNator.pl` and the app spec's static `preflight.policy_data`, which the scheduler falls back to. They had drifted before #16 (the spec had no partition key at all), so they are now asserted to agree by the container acceptance harness.

Verified: preflight emits `runtime=600 partition=gpu2 gpu_count=0` for all three analysis types; `perl -c` clean inside the container.