### PR TITLE
fix: upload results into the job result folder, fixed report name, enforce output_file (#18)

### DIFF
--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -77,9 +77,9 @@
         {
             "id": "output_file",
             "type": "wsfile",
-            "required": 0,
-            "label": "Output File",
-            "desc": "Optional output file path. Not used by this app (outputs go to output_path folder)."
+            "required": 1,
+            "label": "Output Name",
+            "desc": "Job output name. Results land at ${output_path}/.${output_file}/ in the workspace."
         }
     ],
     "preflight": {

--- a/docs/HANDOFF_DEPLOYMENT_TEAM.md
+++ b/docs/HANDOFF_DEPLOYMENT_TEAM.md
@@ -61,15 +61,15 @@ Based on actual benchmarks (see [RUNTIME_METRICS.md](RUNTIME_METRICS.md)):
 {
     "default_cpu": 2,
     "default_memory": "1G",
-    "default_runtime": 120,
+    "default_runtime": 600,
     "preflight": {
         "cpu": 2,
         "memory": "1G",
-        "runtime": 120,
+        "runtime": 600,
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "compute"
+            "partition": "gpu2"
         }
     }
 }

--- a/docs/HANDOFF_UI_TEAM.md
+++ b/docs/HANDOFF_UI_TEAM.md
@@ -74,7 +74,11 @@ Output files follow this pattern:
 - `{input_basename}_proline_summary.tsv` - Ranked proline substitution sites
 - `{input_basename}_disulfide_summary.tsv` - Ranked cysteine (disulfide) sites
 - `{input_basename}_summary.json` - Combined structured summary (for the UI)
-- `{input_basename}_report.html` - **Self-contained HTML report** (workspace type `html`)
+- `stabilinnator_report.html` - **Self-contained HTML report** (workspace type `html`)
+
+The report filename is fixed, not derived from the input structure: each job
+uploads into its own result folder, so there is nothing to disambiguate. It
+keeps the `_report.html` suffix that the portal's REPORT action matches.
 
 ### HTML report (rendered in the portal)
 Every run also produces a single self-contained `*_report.html` uploaded with

--- a/docs/adr/0001-stabilinnator-bvbrc-module-design.md
+++ b/docs/adr/0001-stabilinnator-bvbrc-module-design.md
@@ -47,15 +47,21 @@ startup overhead is counted. The app therefore treats GPU as optional
 - **Consequence:** the preflight must not demand a GPU partition; jobs schedule
   on CPU nodes by default.
 
-- **Amended 2026-08-22:** the consequence above is now qualified. The app is
-  deployed in the shared ProteinPrediction container and must be scheduled where
-  that container is available, so preflight names an explicit partition
-  (currently `compute`) rather than leaving placement to the default. This is a
+- **Amended 2026-08-22, settled 2026-08-24:** the consequence above is now
+  qualified. The app is deployed in the shared ProteinPrediction container and
+  must be scheduled where that container is available, so preflight names an
+  explicit partition rather than leaving placement to the default. This is a
   placement constraint imposed by where the container exists, not a reversal of
   the decision above: inference still runs on CPU by default and preflight still
   requests `gpu_count: 0`. The reasoning about GPU being optional for *compute*
-  stands. If the container turns out not to be hosted on `compute`, the
-  partition moves to `gpu2`.
+  stands.
+
+  `compute` was tried first and failed: jobs dispatched and were placed, but
+  died with empty output because those nodes do not carry the ~27 GB image
+  (tasks 23450798-23450800). The partition is now `gpu2`, whose nodes have the
+  image cached because every PredictStructure job runs there. Runtime also went
+  120s -> 600s, since walltime is dominated by container staging (a cold pull of
+  27 GB is ~3 minutes) rather than by inference, which stays sub-second.
 
 ### 3. Preflight resource requests are driven by measured benchmarks
 

--- a/report/README.md
+++ b/report/README.md
@@ -3,8 +3,8 @@
 `generate_report.py` builds a single self-contained HTML report from a
 stabiliNNator run's outputs. It is called (non-fatally) by
 `service-scripts/App-StabiliNNator.pl` after the TSV/JSON summaries, and the
-resulting `<name>_report.html` is uploaded into the same workspace folder as the
-data files (with workspace type `html`, so the BV-BRC portal renders it).
+resulting `stabilinnator_report.html` is uploaded into the job's result folder
+alongside the data files (with workspace type `html`, so the BV-BRC portal renders it).
 
 ## How it works
 
@@ -32,7 +32,7 @@ Pure standard library — no third-party Python dependencies.
 ```bash
 python generate_report.py \
   --template report_template.html \
-  --output   <name>_report.html \
+  --output   stabilinnator_report.html \
   --input    <input>.pdb \
   --proline  <name>_proline.pdb   --proline-model   proline_gat.pt \
   --disulfide <name>_disulfide.pdb --disulfide-model cys_gat.pt \

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -141,6 +141,16 @@ sub run_stabilinnator {
     print "Starting stabiliNNator protein stability prediction\n";
     print STDERR "Parameters: " . Dumper($params) . "\n" if $ENV{P3_DEBUG};
 
+    # output_path and output_file are both required, and both are checked here
+    # rather than relying on "required": 1 in the app spec. The framework does
+    # not enforce required for output_file: preprocess_parameters runs
+    # "$params->{output_file} =~ s,/,_,g" before its required-check loop, and
+    # that substitution autovivifies the key, so the loop sees it as present.
+    # Without this guard a job missing output_file uploads to "$output_path/."
+    # and lands in a literal "." folder. Same check as App-PredictStructure.pl.
+    die "output_path is required.\n" unless $params->{output_path};
+    die "output_file is required.\n" unless $params->{output_file};
+
     # Create working directories
     my $work_dir = $ENV{P3_WORKDIR} // $ENV{TMPDIR} // "/tmp";
     my $input_dir = "$work_dir/input";

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -702,7 +702,13 @@ sub generate_html_report {
         return;
     }
 
-    my $report  = "$output_dir/${basename}_report.html";
+    # Fixed report filename, not derived from the input structure. Each job now
+    # uploads into its own result folder (see run_stabilinnator), so there is
+    # nothing left to disambiguate, and a predictable name is easier for the UI
+    # and for users to find. Keep the "_report.html" suffix: the BV-BRC-Web
+    # REPORT action (BV-BRC-Web#1403) matches that exact suffix, so a name like
+    # "stabilinnator.report.html" would make the eye icon inert.
+    my $report  = "$output_dir/stabilinnator_report.html";
     my $pro_pdb = "$output_dir/${basename}_proline.pdb";
     my $dis_pdb = "$output_dir/${basename}_disulfide.pdb";
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -269,23 +269,40 @@ sub run_stabilinnator {
         warn "Summary generation failed (continuing with PDB outputs): $_\n";
     };
 
-    # Upload results to workspace
+    # Upload results to workspace.
+    #
+    # Upload into the framework-created result folder ("$output_path/.$output_file"),
+    # NOT into $output_path itself. AppScript::write_results builds the job's
+    # output_files list by ls-ing $app->result_folder(); uploading anywhere else
+    # leaves that folder empty, so the job records "output_files": [] and the
+    # workspace UI (and the REPORT action, which scans output_files for
+    # *_report.html) sees no results at all. Uploading flat also means concurrent
+    # jobs over the same input structure overwrite each other, since our output
+    # filenames derive from the input basename rather than from output_file.
+    #
+    # Fall back to $output_path when result_folder is unset -- that happens on
+    # direct/interactive invocations that bypass the scheduler, where the
+    # framework never called create_result_folder().
     my $output_path = $params->{output_path};
     die "Output path is required\n" unless $output_path;
+
+    my $result_folder = ($app && $app->can('result_folder') ? $app->result_folder() : undef)
+        // $output_path;
+    $result_folder =~ s{/+$}{};      # tolerate a caller-supplied trailing slash
 
     # Generate a self-contained HTML report from the outputs. Runs after the
     # summaries so they are listed in the report's downloads. Non-fatal: the
     # data files must still upload if report generation fails.
     try {
         generate_html_report($output_dir, $input_basename, $analysis_type,
-            $local_input, $output_path, $device, ($hidden_dim // 32),
+            $local_input, $result_folder, $device, ($hidden_dim // 32),
             $prolinnator_model, $disulfinnate_model, ($params->{theme} // 'bvbrc'));
     } catch {
         warn "HTML report generation failed (continuing with data outputs): $_\n";
     };
 
-    print "Uploading results to workspace: $output_path\n";
-    upload_results($app, $output_dir, $output_path);
+    print "Uploading results to workspace: $result_folder\n";
+    upload_results($app, $output_dir, $result_folder);
 
     print "stabiliNNator job completed\n";
     return 0;

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -280,9 +280,16 @@ sub run_stabilinnator {
     # jobs over the same input structure overwrite each other, since our output
     # filenames derive from the input basename rather than from output_file.
     #
-    # Fall back to $output_path when result_folder is unset -- that happens on
-    # direct/interactive invocations that bypass the scheduler, where the
-    # framework never called create_result_folder().
+    # Fall back to $output_path when result_folder is unset. That is NOT the
+    # interactive case -- subproc_run always calls setup_folders, so the folder
+    # exists even at a terminal. It is unset only when skip_workspace_output set
+    # donot_create_result_folder (in which case write_results returns early and
+    # nothing reads output_files), or when $app is a mock in unit tests.
+    #
+    # Deliberately no s{/\.$}{} here, unlike App-PredictStructure.pl: that script
+    # sets donot_create_result_folder, so its strip only ever touches a
+    # caller-supplied path. Stripping a framework result_folder would upload
+    # somewhere other than the folder write_results lists, re-breaking #18.
     my $output_path = $params->{output_path};
     die "Output path is required\n" unless $output_path;
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -286,10 +286,21 @@ sub run_stabilinnator {
     # donot_create_result_folder (in which case write_results returns early and
     # nothing reads output_files), or when $app is a mock in unit tests.
     #
-    # Deliberately no s{/\.$}{} here, unlike App-PredictStructure.pl: that script
-    # sets donot_create_result_folder, so its strip only ever touches a
-    # caller-supplied path. Stripping a framework result_folder would upload
-    # somewhere other than the folder write_results lists, re-breaking #18.
+    # App-PredictStructure.pl additionally strips a trailing "/." here. We do
+    # not, deliberately. That strip only ever fires when output_file is absent
+    # (result_folder is then "$output_path/."), which is a degenerate case with
+    # no good answer: strip it and we upload to $output_path while write_results
+    # still ls's "$output_path/.", so output_files comes back empty -- exactly
+    # the #18 symptom. Leave it and the files land in a literal "." folder,
+    # which is ugly but keeps output_files populated. We prefer the latter.
+    #
+    # The scheduler always supplies output_file, so neither path is reachable in
+    # a real job; the durable fix is making output_file required in the app spec.
+    #
+    # NB: App-PredictStructure.pl's comment at that site claims it called
+    # donot_create_result_folder(1) and that result_folder() is therefore undef.
+    # It does not call it -- grep the file; the string appears only in that
+    # comment. Its result_folder() is set by the framework just like ours.
     my $output_path = $params->{output_path};
     die "Output path is required\n" unless $output_path;
 


### PR DESCRIPTION
Fixes #18.

## Problem

Results were uploaded **flat into `output_path`** instead of into the job's own result folder, so the job recorded `"output_files": []` and delivered nothing from BV-BRC's point of view.

`AppScript::write_results` builds `output_files` by `ls`-ing `$app->result_folder()` — which `create_result_folder()` sets to `"$output_path/.$output_file"`. Uploading anywhere else leaves that folder empty, so the list is empty no matter how much work the job did.

## What's in here

**1. Upload into the result folder** (`fac36de`, `cad44db`, `13721db`)

Upload into `$app->result_folder()`, falling back to `$params->{output_path}` when unset. Mirrors `App-PredictStructure.pl:815`. The report's `--workspace-path` points at the result folder too, so its sibling links resolve.

This unblocks the REPORT eye icon (BV-BRC-Web#1403 scans `output_files` for `*_report.html`), stops concurrent jobs over the same structure from overwriting each other, and makes results attributable to a job.

Two comment corrections are included. Both claims were wrong and are worth not propagating: the fallback is *not* the interactive case (`subproc_run` always calls `setup_folders`, so the folder exists even at a terminal), and `App-PredictStructure.pl` does *not* call `donot_create_result_folder(1)` — that string appears only inside its own comment, so its `result_folder()` is framework-set exactly like ours.

**2. Fixed report filename** (`321b085`)

`<basename>_report.html` → `stabilinnator_report.html`. The input-derived name existed to disambiguate results sharing one directory; with per-job result folders there is nothing left to disambiguate.

The `_report.html` suffix is kept deliberately — the merged handler matches `filename.slice(-"_report.html".length) === "_report.html"`, so a dot-separated name like `stabilinnator.report.html` would leave the icon inert. Data files keep their input-derived names.

**3. `output_file` required, enforced in code** (`90d84b6`, `c04bbe5`)

`output_file` determines where results land but was declared `required: 0` with the desc "Not used by this app". Now `required: 1` with a desc documenting the layout, matching `PredictStructure.json`.

The spec flag alone is not enough: `preprocess_parameters` runs `$params->{output_file} =~ s,/,_,g` *before* its required-check loop, and that substitution autovivifies the key, so the loop sees it as present and never evaluates `required` (verified: `exists()` flips FALSE → TRUE). Without a guard, a job missing `output_file` uploads to `"$output_path/."` and lands in a literal `.` folder. So the check is explicit in the service script, the same way `App-PredictStructure.pl:101-102` does it — which is also what the BV-BRC-Docs API reference documents under "Validation rules enforced by the service".

## Verification

Run in `folding_260821.3.sif` against the live BV-BRC workspace:

| Check | Result |
|---|---|
| Artifacts in `.{output_file}/` | 6/6 |
| Loose files in parent | none (job-result object only) |
| `output_files` count | 6 |
| `*_report.html` present | yes — `stabilinnator_report.html` |
| Web handler match logic replicated | exactly 1 hit |
| `output_file` omitted | rejected before compute or upload |
| `output_file` present | normal run, exit 0 |

## Deployment note

Needs a container rebuild. Every current `folding_*` image still has the flat-upload behavior, so `output_files` stays empty — and the REPORT icon stays inert — until a rebuilt image ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
