### PR TITLE
fix: retry the compute partition, align runtime defaults and docs

### DIFF
--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -89,7 +89,7 @@
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "gpu2"
+            "partition": "compute"
         }
     }
 }

--- a/app_specs/StabiliNNator.json
+++ b/app_specs/StabiliNNator.json
@@ -5,7 +5,7 @@
     "description": "Predict protein stability improvements using Graph Neural Networks. proliNNator predicts proline mutation probabilities at each residue position, while disulfiNNate predicts disulfide bond formation likelihood between cysteine pairs. Both analyses output PDB files with probabilities encoded in the B-factor column (0-1 range).",
     "default_memory": "1G",
     "default_cpu": 2,
-    "default_runtime": 120,
+    "default_runtime": 600,
     "parameters": [
         {
             "id": "input_file",

--- a/docs/HANDOFF_DEPLOYMENT_TEAM.md
+++ b/docs/HANDOFF_DEPLOYMENT_TEAM.md
@@ -69,7 +69,7 @@ Based on actual benchmarks (see [RUNTIME_METRICS.md](RUNTIME_METRICS.md)):
         "storage": "1G",
         "policy_data": {
             "gpu_count": 0,
-            "partition": "gpu2"
+            "partition": "compute"
         }
     }
 }

--- a/docs/adr/0001-stabilinnator-bvbrc-module-design.md
+++ b/docs/adr/0001-stabilinnator-bvbrc-module-design.md
@@ -57,11 +57,19 @@ startup overhead is counted. The app therefore treats GPU as optional
   stands.
 
   `compute` was tried first and failed: jobs dispatched and were placed, but
-  died with empty output because those nodes do not carry the ~27 GB image
-  (tasks 23450798-23450800). The partition is now `gpu2`, whose nodes have the
-  image cached because every PredictStructure job runs there. Runtime also went
+  died with empty output because those nodes did not carry the ~27 GB image
+  (tasks 23450798-23450800). It moved to `gpu2`, whose nodes have the image
+  cached because every PredictStructure job runs there. Runtime also went
   120s -> 600s, since walltime is dominated by container staging (a cold pull of
   27 GB is ~3 minutes) rather than by inference, which stays sub-second.
+
+- **Retried 2026-08-25:** the partition is back to `compute`, deliberately, to
+  retest it now that the image may be staged more widely. `gpu2` placement
+  occupies GPU nodes for inference that is CPU-only by design, so `compute` is
+  the better placement if it works. **`gpu2` remains the known-good fallback:**
+  if jobs again complete with empty output, or die without a `task_status`
+  directory, revert `partition` to `gpu2` in both `service-scripts/App-StabiliNNator.pl`
+  and `app_specs/StabiliNNator.json`.
 
 ### 3. Preflight resource requests are driven by measured benchmarks
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -120,11 +120,14 @@ sub preflight {
             # where that container is available. Inference still runs on CPU by
             # default (faster for these small models), hence gpu_count => 0.
             #
-            # 'compute' was tried first and the jobs did dispatch, but then died
-            # with no output (tasks 23450798-23450800) -- those nodes do not
-            # carry the ~27 GB image. gpu2 nodes demonstrably do: every
-            # PredictStructure job runs there from cache. Verified 2026-08-24.
-            partition => 'gpu2',
+            # 'compute' was tried on 2026-08-24 and the jobs dispatched but then
+            # died with no output (tasks 23450798-23450800) -- those nodes did
+            # not carry the ~27 GB image, so it was reverted to gpu2 (PR #17).
+            # Being retried deliberately: if the image is now staged on the
+            # compute nodes this is the better placement, since it stops
+            # occupying GPU nodes for CPU-only inference. If jobs again die with
+            # empty output, revert to 'gpu2' -- that is the known-good value.
+            partition => 'compute',
         }
     };
 }


### PR DESCRIPTION
Moves preflight placement from `gpu2` back to `compute`, deliberately, to retest it.

## Why retry something that already failed

`353b6cb` (PR #16) set `compute`. Jobs dispatched and were placed, then died with no output at all — tasks 23450798-23450800 ran 2:12, 1:09 and 1:05 with empty stdout/stderr and no `task_status` directory. Those nodes did not carry the ~27 GB shared image. PR #17 reverted to `gpu2`, whose nodes have it cached because every PredictStructure job runs there.

Worth retrying because `gpu2` placement occupies GPU nodes for inference that is CPU-only by design — `gpu_count` stays `0`, and CPU is genuinely faster for these models once CUDA initialization is counted. If the image is now staged on the compute nodes, `compute` is the better placement.

## Rollback

One line, in two files. If jobs again complete with empty output or die without a `task_status` directory, set `partition` back to `gpu2` — the known-good value. Both the code comment and `docs/adr/0001` record this.

## Verification

Preflight emits the new value through the real `AppScript` path in `folding_260825.1.sif` (rc=0):

```json
{ "cpu": 2, "memory": "1G", "runtime": 600, "storage": "1G",
  "policy_data": { "gpu_count": 0, "partition": "compute" } }
```

Both copies are updated — the Perl preflight callback and the app spec's static preflight block, which the scheduler falls back to.

## Deployment

**This needs a container rebuild to take effect.** Preflight runs from the deployed `plbin` copy, so `folding_260825.1.sif` still requests `gpu2` until a new image is built and the `ApplicationDefaultContainer` row points at it.

The test that matters is a scheduler-submitted job after that rebuild: it should land on a compute node and produce output. A completed job with empty output, or a job that dies without a `task_status` directory, is the same failure as 2026-08-24 and means revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
