### PR TITLE
fix: TSV file type, working mmCIF input, and cysteines wrongly ranked as proline candidates

### DIFF
--- a/docs/INPUT_FORMATS.md
+++ b/docs/INPUT_FORMATS.md
@@ -84,8 +84,23 @@ ATOM   1    N  N   . THR A 1 1   ? 9.848   13.298  8.683   1.00 13.04  ? 1   THR
 The service script performs the following validation:
 
 1. **Format detection**: Checks for PDB (ATOM records) or mmCIF (data_/loop_ headers)
-2. **Structure parsing**: Validates that the file can be parsed by BioPython
-3. **Residue check**: Ensures at least one residue with CA atom exists
+2. **mmCIF conversion**: An mmCIF input is converted to PDB with Biopython
+   before the models run. Both `proliNNator.py` and
+   `predict_cysteine_probabilities.py` import only `Bio.PDB.PDBParser` and
+   have no mmCIF reader, so a `.cif` passed straight to `--pdb-path` parses
+   to an empty structure and dies with a bare `StopIteration`.
+3. **Structure parsing**: Validates that the file can be parsed by BioPython
+4. **Residue check**: Ensures at least one residue with CA atom exists
+
+Two mmCIF structures cannot be converted, because PDB format cannot represent
+them. Both are reported rather than silently truncated:
+
+| Case | Limit |
+|---|---|
+| Multi-character chain identifiers | PDB allows one character per chain |
+| More than 99,999 atoms | PDB atom serial numbers stop there |
+
+Multi-model entries are reduced to the first model, for mmCIF and PDB alike.
 
 ## Preparing Input Files
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -435,12 +435,23 @@ sub convert_mmcif_to_pdb {
 import sys
 from Bio.PDB import MMCIFParser, PDBIO
 
+
+def fail(msg):
+    # stdout, not stderr: the caller captures stdout and quotes the last line
+    # back to the user as the reason the job stopped.
+    print(msg)
+    raise SystemExit(1)
+
+
 src, dst = sys.argv[1], sys.argv[2]
-structure = MMCIFParser(QUIET=True).get_structure("input", src)
+try:
+    structure = MMCIFParser(QUIET=True).get_structure("input", src)
+except Exception as exc:
+    fail("could not parse the mmCIF file (%s: %s)" % (type(exc).__name__, exc))
 
 models = list(structure)
 if not models:
-    sys.exit("mmCIF contains no models.")
+    fail("the mmCIF file contains no models.")
 if len(models) > 1:
     print("mmCIF has %d models; keeping the first" % len(models))
     for extra in models[1:]:
@@ -448,14 +459,14 @@ if len(models) > 1:
 
 wide = sorted({c.id for c in structure[models[0].id] if len(c.id) != 1})
 if wide:
-    sys.exit("mmCIF uses multi-character chain identifiers (%s), which PDB "
-             "format cannot represent. Split the structure by chain, or convert "
-             "it to PDB yourself, before submitting." % ", ".join(wide))
+    fail("the mmCIF file uses multi-character chain identifiers (%s), which PDB "
+         "format cannot represent. Split the structure by chain, or convert it "
+         "to PDB yourself, before submitting." % ", ".join(wide))
 
 n_atoms = sum(1 for _ in structure.get_atoms())
 if n_atoms > 99999:
-    sys.exit("mmCIF contains %d atoms; PDB format holds at most 99999. "
-             "Submit a subset of the structure." % n_atoms)
+    fail("the mmCIF file contains %d atoms; PDB format holds at most 99999. "
+         "Submit a subset of the structure." % n_atoms)
 
 io = PDBIO()
 io.set_structure(structure)
@@ -465,12 +476,28 @@ PY_CONVERT
     close($fh);
 
     print "Input is mmCIF; converting to PDB: $cif_path -> $pdb_path\n";
-    my $out = `python "$script" "$cif_path" "$pdb_path" 2>&1`;
-    my $rc  = $?;
-    print $out if defined $out && length $out;
+
+    # List-form exec, no shell. $cif_path ends in basename() of a workspace
+    # object name chosen by the submitter, so it must never be interpolated
+    # into a command line. Everything else in this script already uses
+    # system(@cmd) for the same reason.
+    my $out = '';
+    open(my $ph, '-|', "python", $script, $cif_path, $pdb_path)
+        or die "Could not run the mmCIF converter: $!\n";
+    {
+        local $/;
+        $out = <$ph> // '';
+    }
+    close($ph);
+    my $rc = $?;
+    print $out if length $out;
 
     if ($rc != 0 || ! -s $pdb_path) {
-        die "Could not convert the mmCIF input to PDB.\n";
+        # The converter reports its own reason on stdout; pass it through
+        # rather than replacing it with a generic failure.
+        my ($why) = grep { /\S/ } reverse split /\n/, $out;
+        die "Could not convert the mmCIF input to PDB"
+            . (defined $why ? ": $why\n" : ".\n");
     }
 
     return $pdb_path;
@@ -684,7 +711,7 @@ sub rank_sites {
     my @filtered = @$rows;
     if ($analysis eq 'disulfide') {
         @filtered = grep { $_->{resname} =~ /^(?:CYS|CYX)$/ } @filtered;
-    } else {
+    } elsif ($analysis eq 'proline') {
         @filtered = grep { $_->{resname} !~ /^(?:CYS|CYX)$/ } @filtered;
     }
 

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -173,10 +173,16 @@ sub run_stabilinnator {
     my $file_format = validate_structure_file($local_input);
     print "Detected file format: $file_format\n";
 
+    # Both prediction tools parse with Bio.PDB.PDBParser and have no mmCIF
+    # reader, so an mmCIF handed straight to --pdb-path yields an empty
+    # structure and dies with a bare StopIteration. Convert it first.
+    $local_input = convert_mmcif_to_pdb($local_input, $input_dir)
+        if $file_format eq 'mmCIF';
+
     # Collapse NMR / multi-model ensembles to the first model. The GNN tools
     # otherwise treat every model as extra residues (e.g. a 38-model, 20-residue
     # ensemble becomes 760 concatenated residues).
-    strip_to_first_model($local_input) if $file_format eq 'PDB';
+    strip_to_first_model($local_input);
 
     # Get analysis parameters
     my $analysis_type = $params->{analysis_type} // 'both';
@@ -399,6 +405,77 @@ sub strip_to_first_model {
     write_file($file, @out);
 }
 
+=head2 convert_mmcif_to_pdb
+
+Convert an mmCIF input to PDB so the prediction tools can read it.
+
+proliNNator and disulfiNNate both import only C<Bio::PDB::PDBParser>; neither
+has an mmCIF reader. Biopython ships in the analysis environment, so the
+conversion is done here rather than pushing the burden onto the submitter.
+
+Multi-model entries are reduced to the first model before writing, and the two
+cases PDB format genuinely cannot represent - multi-character chain identifiers
+and more than 99,999 atoms - are reported as such instead of being silently
+truncated.
+
+Returns the path to the converted PDB.
+
+=cut
+
+sub convert_mmcif_to_pdb {
+    my ($cif_path, $work_dir) = @_;
+
+    (my $pdb_path = $cif_path) =~ s/\.(cif|mmcif)$//i;
+    $pdb_path .= ".pdb";
+    $pdb_path = "$cif_path.pdb" if $pdb_path eq $cif_path;
+
+    my $script = "$work_dir/mmcif_to_pdb.py";
+    open(my $fh, '>', $script) or die "Cannot write $script: $!\n";
+    print $fh <<'PY_CONVERT';
+import sys
+from Bio.PDB import MMCIFParser, PDBIO
+
+src, dst = sys.argv[1], sys.argv[2]
+structure = MMCIFParser(QUIET=True).get_structure("input", src)
+
+models = list(structure)
+if not models:
+    sys.exit("mmCIF contains no models.")
+if len(models) > 1:
+    print("mmCIF has %d models; keeping the first" % len(models))
+    for extra in models[1:]:
+        structure.detach_child(extra.id)
+
+wide = sorted({c.id for c in structure[models[0].id] if len(c.id) != 1})
+if wide:
+    sys.exit("mmCIF uses multi-character chain identifiers (%s), which PDB "
+             "format cannot represent. Split the structure by chain, or convert "
+             "it to PDB yourself, before submitting." % ", ".join(wide))
+
+n_atoms = sum(1 for _ in structure.get_atoms())
+if n_atoms > 99999:
+    sys.exit("mmCIF contains %d atoms; PDB format holds at most 99999. "
+             "Submit a subset of the structure." % n_atoms)
+
+io = PDBIO()
+io.set_structure(structure)
+io.save(dst)
+print("converted %d atoms" % n_atoms)
+PY_CONVERT
+    close($fh);
+
+    print "Input is mmCIF; converting to PDB: $cif_path -> $pdb_path\n";
+    my $out = `python "$script" "$cif_path" "$pdb_path" 2>&1`;
+    my $rc  = $?;
+    print $out if defined $out && length $out;
+
+    if ($rc != 0 || ! -s $pdb_path) {
+        die "Could not convert the mmCIF input to PDB.\n";
+    }
+
+    return $pdb_path;
+}
+
 =head2 determine_device
 
 Determine the compute device to use based on accelerator parameter.
@@ -486,6 +563,11 @@ sub upload_results {
                 my $type = "txt";
                 if ($file =~ /\.(pdb|cif|mmcif)$/i) {
                     $type = "pdb";
+                } elsif ($file =~ /\.tsv$/i) {
+                    # 'tsv' is a first-class workspace type (Workspace typeslist.txt);
+                    # typing these as 'txt' made the browser fall back to a filename
+                    # heuristic instead of the tabular viewer.
+                    $type = "tsv";
                 } elsif ($file =~ /\.json$/i) {
                     $type = "json";
                 } elsif ($file =~ /\.html?$/i) {

--- a/service-scripts/App-StabiliNNator.pl
+++ b/service-scripts/App-StabiliNNator.pl
@@ -660,9 +660,21 @@ sub _trim {
 Given parsed residue rows and an analysis type, return the rows sorted by
 probability descending, filtered as appropriate for the analysis:
 
-  * proline  - all standard residues (existing PRO kept, flagged by caller)
-  * disulfide - only CYS/CYX residues (the model annotates every residue, but
-    only cysteines are biologically meaningful for disulfide formation)
+  * proline  - all standard residues except CYS/CYX (existing PRO kept,
+    flagged by caller)
+  * disulfide - only CYS/CYX residues
+
+Both models annotate every residue in the output PDB; the filtering here is
+what makes each ranking mean what its name says.
+
+Cysteines are excluded from the proline ranking because substituting one is
+not an available move: it either breaks an existing disulfide or removes a
+free thiol, and the service scores disulfide potential separately for exactly
+those positions. Without this filter crambin's CYS 40 ranks third at 0.80 in
+the proline summary - a suggestion to break a disulfide - while the HTML
+report, which has always applied the filter (report/generate_report.py), shows
+40 sites and never lists it. The two views disagreed, and the data files were
+the wrong one.
 
 =cut
 
@@ -672,6 +684,8 @@ sub rank_sites {
     my @filtered = @$rows;
     if ($analysis eq 'disulfide') {
         @filtered = grep { $_->{resname} =~ /^(?:CYS|CYX)$/ } @filtered;
+    } else {
+        @filtered = grep { $_->{resname} !~ /^(?:CYS|CYX)$/ } @filtered;
     }
 
     return [ sort { $b->{prob} <=> $a->{prob} } @filtered ];


### PR DESCRIPTION
Two defects surfaced by the BV-BRC alpha review (`ProteinStabilityPredictionAlphaReview.docx`), relayed via the PredictStructureApp session.

## 1. Ranked summaries uploaded as type `txt`

The reviewer noticed `1crn_small_disulfide_summary.tsv` sitting in the workspace with type `txt`.

`tsv` is a first-class workspace type (`Workspace/typeslist.txt:63`) and `BV-BRC-Web/public/js/p3/widget/WorkspaceBrowser.js:2909-2913` routes it to the `TSV_CSV` tabular viewer. `txt` falls through to the default branch, which guesses from the filename. The type map in `upload_results()` simply had no `tsv` case.

One-line class of fix. **Affects new uploads only** — objects already in the workspace keep the type they were written with.

> `App-PredictStructure.pl` has the same gap (`csv => "csv"` but no `tsv`). That is the PredictStructureApp session's repo; flagged to them, not changed here.

## 2. mmCIF input was accepted and then crashed

`validate_structure_file()` recognises mmCIF, and the app spec, the submission form and the quick reference all advertise mmCIF support. But both prediction tools import only `Bio.PDB.PDBParser` — neither has an mmCIF reader:

```
$ grep -n "from Bio" /opt/stabilinnator/proliNNator/proliNNator.py
32:from Bio.PDB import PDBIO, PDBParser, is_aa
```

So a `.cif` handed to `--pdb-path` parsed to an empty structure. Reproduced against `folding_260825.2.sif`:

```
File "proliNNator.py", line 178, in structure_to_graph
    model = next(structure.get_models())
StopIteration
```

No output file, no useful message. This matters more than usual right now: the reviewer raised mmCIF specifically because wwPDB has deprecated PDB format for large structures.

`convert_mmcif_to_pdb()` converts with Biopython (already in the analysis environment) before the tools run:

- multi-model entries reduced to the first model, matching existing PDB behaviour
- the two things PDB format genuinely **cannot** represent are reported rather than silently truncated: multi-character chain IDs, and >99,999 atoms
- `strip_to_first_model()` is now unconditional, since after conversion every input reaching the tools is PDB

### Verification

`1crn_small.pdb` → mmCIF → back through the new path gives per-residue proline probabilities **identical** to running the original PDB directly, 46/46 CA records:

```
CA residues: orig=46 cif-route=46
identical
```

`perl -c` clean inside the container.

## Not in this PR

- The form's `WorkspaceObjectSelector` accepts `["txt","unspecified","pdb"]`, so a workspace object correctly typed `cif`/`mmcif` cannot be picked even now that the backend handles it. Fixed on the BV-BRC-Web side.
- Docs updates (determinism, where the B-factor column lives, mmCIF caveats) go to BV-BRC-Docs.

## Deployment

Needs a container rebuild — preflight and the service script run from the deployed `plbin` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
