### PR TITLE
fix: label ranked residues by their own identity, not by sequence offset

### DIFF
--- a/report/report_template.html
+++ b/report/report_template.html
@@ -331,7 +331,7 @@ const hideTip=()=>tip.style.opacity=0;
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Top proline site</div>
       <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(resLabel(cand))} — strongest substitution candidate</div></div>`);
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Proline sites scored</div>
-      <div class="v">${s.length}</div><div class="cap">every residue ranked; ${nPro} already proline</div></div>`);
+      <div class="v">${s.length}</div><div class="cap">cysteines excluded; ${nPro} already proline</div></div>`);
   }
   if(hasDis){
     const s=analysis('disulfide').sites;
@@ -552,11 +552,13 @@ function renderBars(mount, rows, cls, kind){
 /* data table */
 (()=>{
   const thead=document.querySelector('#dataTable thead'), tb=document.querySelector('#dataTable tbody');
-  const cols=['Pos','Residue']; if(hasPro)cols.push('Proline p'); if(hasDis)cols.push('Disulfide p'); cols.push('Note');
-  thead.innerHTML='<tr>'+cols.map((c,k)=>`<th${k>1&&k<cols.length-1?' class="num"':''}>${esc(c)}</th>`).join('')+'</tr>';
+  const cols=(MULTICHAIN?['Chain']:[]).concat(['Pos','Residue']);
+  const firstNum=cols.length;   // score columns start after the identity columns
+  if(hasPro)cols.push('Proline p'); if(hasDis)cols.push('Disulfide p'); cols.push('Note');
+  thead.innerHTML='<tr>'+cols.map((c,k)=>`<th${k>=firstNum&&k<cols.length-1?' class="num"':''}>${esc(c)}</th>`).join('')+'</tr>';
   DATA.per_residue.forEach(r=>{
     const note=r.res==='PRO'?'already PRO':(r.is_cys?'cysteine':'');
-    let tds=`<td>${r.pos}</td><td>${esc(r.res)}</td>`;
+    let tds=(MULTICHAIN?`<td>${esc(r.chain)}</td>`:'')+`<td>${r.pos}</td><td>${esc(r.res)}</td>`;
     if(hasPro)tds+=`<td class="num">${r.proline_p==null?'—':r.proline_p.toFixed(2)}</td>`;
     if(hasDis)tds+=`<td class="num">${r.disulfide_p==null?'—':r.disulfide_p.toFixed(2)}</td>`;
     tds+=`<td style="font-family:var(--sans);color:var(--muted)">${esc(note)}</td>`;

--- a/report/report_template.html
+++ b/report/report_template.html
@@ -99,7 +99,8 @@ figure{margin:0}
 .axis-lab{font-family:var(--mono); font-size:9px; fill:var(--faint)}
 .hcell text{font-family:var(--mono); pointer-events:none}
 .bars{display:flex; flex-direction:column; gap:7px; margin-top:4px}
-.bar-row{display:grid; grid-template-columns:120px 100px 1fr; align-items:center; gap:0 12px}
+.bar-row{display:grid; grid-template-columns:120px 1fr; align-items:center; gap:0 12px}
+.bar-row.has-tag{grid-template-columns:120px 100px 1fr}
 .bar-tag{min-width:0; white-space:nowrap}
 .bar-lab{font-family:var(--mono); font-size:12.5px; color:var(--body); text-align:right; white-space:nowrap}
 .bar-lab b{color:var(--ink); font-weight:600}
@@ -506,16 +507,20 @@ const hideTip=()=>tip.style.opacity=0;
 /* bar charts */
 function renderBars(mount, rows, cls, kind){
   rows.forEach(r=>{
-    const row=document.createElement('div'); row.className='bar-row';
+    // Only the proline chart can carry a badge; reserving its column in the
+    // disulfide chart would narrow those bars for nothing.
+    const row=document.createElement('div'); row.className='bar-row'+(kind==='pro'?' has-tag':'');
     const isPro=r.res==='PRO';
     const lab=document.createElement('div'); lab.className='bar-lab';
     lab.innerHTML=`<b>${esc(resLabel(r))}</b>`;
     row.appendChild(lab);
     // Own grid cell: as part of the label it overflowed the fixed-width column
     // and the bar track painted over it.
-    const tagCell=document.createElement('div'); tagCell.className='bar-tag';
-    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
-    row.appendChild(tagCell);
+    if(kind==='pro'){
+      const tagCell=document.createElement('div'); tagCell.className='bar-tag';
+      if(isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
+      row.appendChild(tagCell);
+    }
     const track=document.createElement('div'); track.className='bar-track';
     const fill=document.createElement('div'); fill.className='bar-fill '+cls; fill.style.width=Math.max(r.prob*100,1.5)+'%';
     const inside=r.prob>=0.30;

--- a/report/report_template.html
+++ b/report/report_template.html
@@ -99,7 +99,8 @@ figure{margin:0}
 .axis-lab{font-family:var(--mono); font-size:9px; fill:var(--faint)}
 .hcell text{font-family:var(--mono); pointer-events:none}
 .bars{display:flex; flex-direction:column; gap:7px; margin-top:4px}
-.bar-row{display:grid; grid-template-columns:120px 1fr; align-items:center; gap:12px}
+.bar-row{display:grid; grid-template-columns:120px 100px 1fr; align-items:center; gap:0 12px}
+.bar-tag{min-width:0; white-space:nowrap}
 .bar-lab{font-family:var(--mono); font-size:12.5px; color:var(--body); text-align:right; white-space:nowrap}
 .bar-lab b{color:var(--ink); font-weight:600}
 .bar-track{position:relative; height:22px; background:var(--sunken); border-radius:5px}
@@ -238,7 +239,12 @@ const DATA = JSON.parse(document.getElementById('report-data').textContent);
 const SVGNS="http://www.w3.org/2000/svg";
 const el=(t,a={})=>{const e=document.createElementNS(SVGNS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
 const esc=s=>String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const AA3={A:"ALA",R:"ARG",N:"ASN",D:"ASP",C:"CYS",Q:"GLN",E:"GLU",G:"GLY",H:"HIS",I:"ILE",L:"LEU",K:"LYS",M:"MET",F:"PHE",P:"PRO",S:"SER",T:"THR",W:"TRP",Y:"TYR",V:"VAL"};
+/* Residue numbering is per chain and need not start at 1, so a residue is
+   identified by chain + number. The chain is shown only when there is more
+   than one, to keep single-chain reports uncluttered. */
+const MULTICHAIN=(DATA.input.chains||[]).length>1;
+const resTag=(chain,pos)=>MULTICHAIN?`${chain}${pos}`:`${pos}`;
+const resLabel=r=>MULTICHAIN?`${r.chain} ${r.res} ${r.pos}`:`${r.res} ${r.pos}`;
 const analysis=k=>DATA.analyses.find(a=>a.key===k);
 const hasPro=!!analysis('proline'), hasDis=!!analysis('disulfide');
 const perByPos={}; DATA.per_residue.forEach(r=>perByPos[r.chain+'/'+r.pos]=r);
@@ -276,20 +282,25 @@ const hideTip=()=>tip.style.opacity=0;
     `The job analyzed ${i.name} — ${i.n_residues} residues across ${i.chains.length} chain`+
     `${i.chains.length>1?'s':''} (${i.chains.join(', ')}), including ${i.cys_positions.length} cysteine`+
     `${i.cys_positions.length===1?'':'s'}.`;
+  // Two chains can both carry a CYS 40; without the chain the list reads as
+  // a duplicate.
+  const cysLabels=(DATA.per_residue||[]).filter(p=>p.is_cys).map(p=>resTag(p.chain,p.pos));
   const dl=document.getElementById('in-dl'); const rows=[
     ['Structure', i.header? `${i.name} — ${i.header}` : i.name],
     ['File', i.file],
     ['Chains', i.chains.join(', ')||'—'],
     ['Residues', String(i.n_residues)],
-    ['Cysteines', i.cys_positions.length? `${i.cys_positions.length} · pos ${i.cys_positions.join(', ')}` : '0'],
+    ['Cysteines', cysLabels.length? `${cysLabels.length} · pos ${cysLabels.join(', ')}` : '0'],
   ];
   dl.innerHTML=rows.map(([k,v])=>`<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`).join('');
   if(i.title){document.getElementById('in-title').textContent=`“${i.title}”`;}
   else{document.getElementById('in-title-lab').classList.add('hidden');document.getElementById('in-title').classList.add('hidden');}
-  const cys=new Set(i.cys_positions); let html='';
-  for(let k=0;k<i.sequence.length;k++){const pos=k+1;
-    html+=cys.has(pos)?`<span class="cys">${i.sequence[k]}</span>`:i.sequence[k];
-    if(pos%10===0)html+=' ';}
+  // per_residue is index-aligned with the sequence string; cys_positions
+  // holds residue numbers, which are not sequence offsets.
+  const pr=DATA.per_residue||[]; let html='';
+  for(let k=0;k<i.sequence.length;k++){
+    html+=(pr[k]&&pr[k].is_cys)?`<span class="cys">${i.sequence[k]}</span>`:i.sequence[k];
+    if((k+1)%10===0)html+=' ';}
   document.getElementById('in-seq').innerHTML=html;
 })();
 
@@ -317,7 +328,7 @@ const hideTip=()=>tip.style.opacity=0;
     const cand=s.find(x=>!x.already_pro)||s[0];
     const nPro=s.filter(x=>x.already_pro).length;
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Top proline site</div>
-      <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(AA3[DATA.input.sequence[cand.pos-1]]||cand.res)} ${cand.pos} — strongest substitution candidate</div></div>`);
+      <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(resLabel(cand))} — strongest substitution candidate</div></div>`);
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Proline sites scored</div>
       <div class="v">${s.length}</div><div class="cap">every residue ranked; ${nPro} already proline</div></div>`);
   }
@@ -346,7 +357,7 @@ const hideTip=()=>tip.style.opacity=0;
     const cand=s.find(x=>!x.already_pro)||s[0];
     const nPro=s.filter(x=>x.already_pro).length;
     html+=`<div class="note"><b>Reading the proline scores.</b> The leading substitution candidate is `+
-      `<b>${esc(AA3[DATA.input.sequence[cand.pos-1]]||cand.res)}${cand.pos} (${cand.prob.toFixed(2)})</b>. `+
+      `<b>${esc(resLabel(cand))} (${cand.prob.toFixed(2)})</b>. `+
       `${nPro} ranked residue${nPro===1?' is':'s are'} already proline — the model recognizes its own favored motif; `+
       `these are flagged, not substitution targets.</div>`;
   }
@@ -498,16 +509,20 @@ function renderBars(mount, rows, cls, kind){
     const row=document.createElement('div'); row.className='bar-row';
     const isPro=r.res==='PRO';
     const lab=document.createElement('div'); lab.className='bar-lab';
-    lab.innerHTML=`<b>${esc(AA3[DATA.input.sequence[r.pos-1]]||r.res)} ${r.pos}</b>`;
-    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';lab.appendChild(tg);}
+    lab.innerHTML=`<b>${esc(resLabel(r))}</b>`;
     row.appendChild(lab);
+    // Own grid cell: as part of the label it overflowed the fixed-width column
+    // and the bar track painted over it.
+    const tagCell=document.createElement('div'); tagCell.className='bar-tag';
+    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
+    row.appendChild(tagCell);
     const track=document.createElement('div'); track.className='bar-track';
     const fill=document.createElement('div'); fill.className='bar-fill '+cls; fill.style.width=Math.max(r.prob*100,1.5)+'%';
     const inside=r.prob>=0.30;
     const val=document.createElement('span'); val.className='bar-val '+(inside?'in':'out'); val.textContent=r.prob.toFixed(2);
     (inside?fill:track).appendChild(val);
     track.appendChild(fill); row.appendChild(track);
-    const html=`<b>${esc(AA3[DATA.input.sequence[r.pos-1]]||r.res)} ${r.pos}</b><br>${kind==='pro'?'proline':'disulfide'} p = ${r.prob.toFixed(2)}`+(isPro&&kind==='pro'?'<br><i>already proline</i>':'');
+    const html=`<b>${esc(resLabel(r))}</b><br>${kind==='pro'?'proline':'disulfide'} p = ${r.prob.toFixed(2)}`+(isPro&&kind==='pro'?'<br><i>already proline</i>':'');
     row.addEventListener('mousemove',e=>showTip(html,e.clientX,e.clientY));
     row.addEventListener('mouseleave',hideTip);
     mount.appendChild(row);
@@ -564,7 +579,11 @@ function renderBars(mount, rows, cls, kind){
      <p style="max-width:72ch;margin:14px 0 0">Per-residue probabilities are stabiliNNator GNN scores encoded in the PDB
      B-factor column (0–1). The disulfide model returns a per-cysteine propensity, not explicit pairings — the bonds shown
      are detected from the input structure by cysteine S–S distance (≤ 2.5 Å). Generated ${esc(DATA.generated)} by the
-     BV-BRC <code>App-StabiliNNator</code> service.</p>`+
+     BV-BRC <code>App-StabiliNNator</code> service.</p>
+     <p style="max-width:72ch;margin:10px 0 0">If you use this result in a publication, please cite:
+     Olson RD <i>et al.</i> <b>Introducing the Bacterial and Viral Bioinformatics Resource Center (BV-BRC):
+     a resource combining PATRIC, IRD and ViPR.</b> <i>Nucleic Acids Research</i> 51(D1), D678–D689 (2023).
+     <a href="https://doi.org/10.1093/nar/gkac1003" target="_blank" rel="noopener">doi:10.1093/nar/gkac1003</a></p>`+
     (DATA.source&&DATA.source.repo?`<p style="max-width:72ch;margin:10px 0 0">Prediction models: <b>stabiliNNator</b>
      (proliNNator + disulfiNNate) — source <a href="${esc(DATA.source.repo)}" target="_blank" rel="noopener">${esc(DATA.source.repo.replace(/^https?:\/\/(www\.)?github\.com\//,''))}</a>${DATA.source.commit?` @ <code>${esc(DATA.source.commit)}</code>`:''}.</p>`:'');
 })();

--- a/report/report_template_bvbrc.html
+++ b/report/report_template_bvbrc.html
@@ -353,7 +353,7 @@ const hideTip=()=>tip.style.opacity=0;
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Top proline site</div>
       <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(resLabel(cand))} — strongest substitution candidate</div></div>`);
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Proline sites scored</div>
-      <div class="v">${s.length}</div><div class="cap">every residue ranked; ${nPro} already proline</div></div>`);
+      <div class="v">${s.length}</div><div class="cap">cysteines excluded; ${nPro} already proline</div></div>`);
   }
   if(hasDis){
     const s=analysis('disulfide').sites;
@@ -574,11 +574,13 @@ function renderBars(mount, rows, cls, kind){
 /* data table */
 (()=>{
   const thead=document.querySelector('#dataTable thead'), tb=document.querySelector('#dataTable tbody');
-  const cols=['Pos','Residue']; if(hasPro)cols.push('Proline p'); if(hasDis)cols.push('Disulfide p'); cols.push('Note');
-  thead.innerHTML='<tr>'+cols.map((c,k)=>`<th${k>1&&k<cols.length-1?' class="num"':''}>${esc(c)}</th>`).join('')+'</tr>';
+  const cols=(MULTICHAIN?['Chain']:[]).concat(['Pos','Residue']);
+  const firstNum=cols.length;   // score columns start after the identity columns
+  if(hasPro)cols.push('Proline p'); if(hasDis)cols.push('Disulfide p'); cols.push('Note');
+  thead.innerHTML='<tr>'+cols.map((c,k)=>`<th${k>=firstNum&&k<cols.length-1?' class="num"':''}>${esc(c)}</th>`).join('')+'</tr>';
   DATA.per_residue.forEach(r=>{
     const note=r.res==='PRO'?'already PRO':(r.is_cys?'cysteine':'');
-    let tds=`<td>${r.pos}</td><td>${esc(r.res)}</td>`;
+    let tds=(MULTICHAIN?`<td>${esc(r.chain)}</td>`:'')+`<td>${r.pos}</td><td>${esc(r.res)}</td>`;
     if(hasPro)tds+=`<td class="num">${r.proline_p==null?'—':r.proline_p.toFixed(2)}</td>`;
     if(hasDis)tds+=`<td class="num">${r.disulfide_p==null?'—':r.disulfide_p.toFixed(2)}</td>`;
     tds+=`<td style="font-family:var(--sans);color:var(--muted)">${esc(note)}</td>`;

--- a/report/report_template_bvbrc.html
+++ b/report/report_template_bvbrc.html
@@ -112,7 +112,8 @@ figure{margin:0}
 .hcell text{font-family:var(--mono); pointer-events:none}
 /* Bars */
 .bars{display:flex; flex-direction:column; gap:6px; margin-top:4px}
-.bar-row{display:grid; grid-template-columns:118px 100px 1fr; align-items:center; gap:0 11px}
+.bar-row{display:grid; grid-template-columns:118px 1fr; align-items:center; gap:0 11px}
+.bar-row.has-tag{grid-template-columns:118px 100px 1fr}
 .bar-tag{min-width:0; white-space:nowrap}
 .bar-lab{font-family:var(--mono); font-size:12px; color:var(--body); text-align:right; white-space:nowrap}
 .bar-lab b{color:var(--ink); font-weight:700}
@@ -528,16 +529,20 @@ const hideTip=()=>tip.style.opacity=0;
 /* bar charts */
 function renderBars(mount, rows, cls, kind){
   rows.forEach(r=>{
-    const row=document.createElement('div'); row.className='bar-row';
+    // Only the proline chart can carry a badge; reserving its column in the
+    // disulfide chart would narrow those bars for nothing.
+    const row=document.createElement('div'); row.className='bar-row'+(kind==='pro'?' has-tag':'');
     const isPro=r.res==='PRO';
     const lab=document.createElement('div'); lab.className='bar-lab';
     lab.innerHTML=`<b>${esc(resLabel(r))}</b>`;
     row.appendChild(lab);
     // Own grid cell: as part of the label it overflowed the fixed-width column
     // and the bar track painted over it.
-    const tagCell=document.createElement('div'); tagCell.className='bar-tag';
-    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
-    row.appendChild(tagCell);
+    if(kind==='pro'){
+      const tagCell=document.createElement('div'); tagCell.className='bar-tag';
+      if(isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
+      row.appendChild(tagCell);
+    }
     const track=document.createElement('div'); track.className='bar-track';
     const fill=document.createElement('div'); fill.className='bar-fill '+cls; fill.style.width=Math.max(r.prob*100,1.5)+'%';
     const inside=r.prob>=0.30;

--- a/report/report_template_bvbrc.html
+++ b/report/report_template_bvbrc.html
@@ -112,7 +112,8 @@ figure{margin:0}
 .hcell text{font-family:var(--mono); pointer-events:none}
 /* Bars */
 .bars{display:flex; flex-direction:column; gap:6px; margin-top:4px}
-.bar-row{display:grid; grid-template-columns:118px 1fr; align-items:center; gap:11px}
+.bar-row{display:grid; grid-template-columns:118px 100px 1fr; align-items:center; gap:0 11px}
+.bar-tag{min-width:0; white-space:nowrap}
 .bar-lab{font-family:var(--mono); font-size:12px; color:var(--body); text-align:right; white-space:nowrap}
 .bar-lab b{color:var(--ink); font-weight:700}
 .bar-track{position:relative; height:21px; background:var(--sunken); border-radius:3px; border:1px solid var(--line)}
@@ -260,7 +261,12 @@ const DATA = JSON.parse(document.getElementById('report-data').textContent);
 const SVGNS="http://www.w3.org/2000/svg";
 const el=(t,a={})=>{const e=document.createElementNS(SVGNS,t);for(const k in a)e.setAttribute(k,a[k]);return e;};
 const esc=s=>String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const AA3={A:"ALA",R:"ARG",N:"ASN",D:"ASP",C:"CYS",Q:"GLN",E:"GLU",G:"GLY",H:"HIS",I:"ILE",L:"LEU",K:"LYS",M:"MET",F:"PHE",P:"PRO",S:"SER",T:"THR",W:"TRP",Y:"TYR",V:"VAL"};
+/* Residue numbering is per chain and need not start at 1, so a residue is
+   identified by chain + number. The chain is shown only when there is more
+   than one, to keep single-chain reports uncluttered. */
+const MULTICHAIN=(DATA.input.chains||[]).length>1;
+const resTag=(chain,pos)=>MULTICHAIN?`${chain}${pos}`:`${pos}`;
+const resLabel=r=>MULTICHAIN?`${r.chain} ${r.res} ${r.pos}`:`${r.res} ${r.pos}`;
 const analysis=k=>DATA.analyses.find(a=>a.key===k);
 const hasPro=!!analysis('proline'), hasDis=!!analysis('disulfide');
 const perByPos={}; DATA.per_residue.forEach(r=>perByPos[r.chain+'/'+r.pos]=r);
@@ -298,20 +304,25 @@ const hideTip=()=>tip.style.opacity=0;
     `The job analyzed ${i.name} — ${i.n_residues} residues across ${i.chains.length} chain`+
     `${i.chains.length>1?'s':''} (${i.chains.join(', ')}), including ${i.cys_positions.length} cysteine`+
     `${i.cys_positions.length===1?'':'s'}.`;
+  // Two chains can both carry a CYS 40; without the chain the list reads as
+  // a duplicate.
+  const cysLabels=(DATA.per_residue||[]).filter(p=>p.is_cys).map(p=>resTag(p.chain,p.pos));
   const dl=document.getElementById('in-dl'); const rows=[
     ['Structure', i.header? `${i.name} — ${i.header}` : i.name],
     ['File', i.file],
     ['Chains', i.chains.join(', ')||'—'],
     ['Residues', String(i.n_residues)],
-    ['Cysteines', i.cys_positions.length? `${i.cys_positions.length} · pos ${i.cys_positions.join(', ')}` : '0'],
+    ['Cysteines', cysLabels.length? `${cysLabels.length} · pos ${cysLabels.join(', ')}` : '0'],
   ];
   dl.innerHTML=rows.map(([k,v])=>`<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`).join('');
   if(i.title){document.getElementById('in-title').textContent=`“${i.title}”`;}
   else{document.getElementById('in-title-lab').classList.add('hidden');document.getElementById('in-title').classList.add('hidden');}
-  const cys=new Set(i.cys_positions); let html='';
-  for(let k=0;k<i.sequence.length;k++){const pos=k+1;
-    html+=cys.has(pos)?`<span class="cys">${i.sequence[k]}</span>`:i.sequence[k];
-    if(pos%10===0)html+=' ';}
+  // per_residue is index-aligned with the sequence string; cys_positions
+  // holds residue numbers, which are not sequence offsets.
+  const pr=DATA.per_residue||[]; let html='';
+  for(let k=0;k<i.sequence.length;k++){
+    html+=(pr[k]&&pr[k].is_cys)?`<span class="cys">${i.sequence[k]}</span>`:i.sequence[k];
+    if((k+1)%10===0)html+=' ';}
   document.getElementById('in-seq').innerHTML=html;
 })();
 
@@ -339,7 +350,7 @@ const hideTip=()=>tip.style.opacity=0;
     const cand=s.find(x=>!x.already_pro)||s[0];
     const nPro=s.filter(x=>x.already_pro).length;
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Top proline site</div>
-      <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(AA3[DATA.input.sequence[cand.pos-1]]||cand.res)} ${cand.pos} — strongest substitution candidate</div></div>`);
+      <div class="v">${cand.prob.toFixed(2)}</div><div class="cap">${esc(resLabel(cand))} — strongest substitution candidate</div></div>`);
     T.push(`<div class="tile pro"><span class="rail"></span><div class="k">Proline sites scored</div>
       <div class="v">${s.length}</div><div class="cap">every residue ranked; ${nPro} already proline</div></div>`);
   }
@@ -368,7 +379,7 @@ const hideTip=()=>tip.style.opacity=0;
     const cand=s.find(x=>!x.already_pro)||s[0];
     const nPro=s.filter(x=>x.already_pro).length;
     html+=`<div class="note"><b>Reading the proline scores.</b> The leading substitution candidate is `+
-      `<b>${esc(AA3[DATA.input.sequence[cand.pos-1]]||cand.res)}${cand.pos} (${cand.prob.toFixed(2)})</b>. `+
+      `<b>${esc(resLabel(cand))} (${cand.prob.toFixed(2)})</b>. `+
       `${nPro} ranked residue${nPro===1?' is':'s are'} already proline — the model recognizes its own favored motif; `+
       `these are flagged, not substitution targets.</div>`;
   }
@@ -520,16 +531,20 @@ function renderBars(mount, rows, cls, kind){
     const row=document.createElement('div'); row.className='bar-row';
     const isPro=r.res==='PRO';
     const lab=document.createElement('div'); lab.className='bar-lab';
-    lab.innerHTML=`<b>${esc(AA3[DATA.input.sequence[r.pos-1]]||r.res)} ${r.pos}</b>`;
-    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';lab.appendChild(tg);}
+    lab.innerHTML=`<b>${esc(resLabel(r))}</b>`;
     row.appendChild(lab);
+    // Own grid cell: as part of the label it overflowed the fixed-width column
+    // and the bar track painted over it.
+    const tagCell=document.createElement('div'); tagCell.className='bar-tag';
+    if(kind==='pro'&&isPro){const tg=document.createElement('span');tg.className='tag';tg.textContent='already PRO';tagCell.appendChild(tg);}
+    row.appendChild(tagCell);
     const track=document.createElement('div'); track.className='bar-track';
     const fill=document.createElement('div'); fill.className='bar-fill '+cls; fill.style.width=Math.max(r.prob*100,1.5)+'%';
     const inside=r.prob>=0.30;
     const val=document.createElement('span'); val.className='bar-val '+(inside?'in':'out'); val.textContent=r.prob.toFixed(2);
     (inside?fill:track).appendChild(val);
     track.appendChild(fill); row.appendChild(track);
-    const html=`<b>${esc(AA3[DATA.input.sequence[r.pos-1]]||r.res)} ${r.pos}</b><br>${kind==='pro'?'proline':'disulfide'} p = ${r.prob.toFixed(2)}`+(isPro&&kind==='pro'?'<br><i>already proline</i>':'');
+    const html=`<b>${esc(resLabel(r))}</b><br>${kind==='pro'?'proline':'disulfide'} p = ${r.prob.toFixed(2)}`+(isPro&&kind==='pro'?'<br><i>already proline</i>':'');
     row.addEventListener('mousemove',e=>showTip(html,e.clientX,e.clientY));
     row.addEventListener('mouseleave',hideTip);
     mount.appendChild(row);
@@ -586,7 +601,11 @@ function renderBars(mount, rows, cls, kind){
      <p style="max-width:72ch;margin:14px 0 0">Per-residue probabilities are stabiliNNator GNN scores encoded in the PDB
      B-factor column (0–1). The disulfide model returns a per-cysteine propensity, not explicit pairings — the bonds shown
      are detected from the input structure by cysteine S–S distance (≤ 2.5 Å). Generated ${esc(DATA.generated)} by the
-     BV-BRC <code>App-StabiliNNator</code> service.</p>`+
+     BV-BRC <code>App-StabiliNNator</code> service.</p>
+     <p style="max-width:72ch;margin:10px 0 0">If you use this result in a publication, please cite:
+     Olson RD <i>et al.</i> <b>Introducing the Bacterial and Viral Bioinformatics Resource Center (BV-BRC):
+     a resource combining PATRIC, IRD and ViPR.</b> <i>Nucleic Acids Research</i> 51(D1), D678–D689 (2023).
+     <a href="https://doi.org/10.1093/nar/gkac1003" target="_blank" rel="noopener">doi:10.1093/nar/gkac1003</a></p>`+
     (DATA.source&&DATA.source.repo?`<p style="max-width:72ch;margin:10px 0 0">Prediction models: <b>stabiliNNator</b>
      (proliNNator + disulfiNNate) — source <a href="${esc(DATA.source.repo)}" target="_blank" rel="noopener">${esc(DATA.source.repo.replace(/^https?:\/\/(www\.)?github\.com\//,''))}</a>${DATA.source.commit?` @ <code>${esc(DATA.source.commit)}</code>`:''}.</p>`:'');
 })();

--- a/tests/verify_report_labels.js
+++ b/tests/verify_report_labels.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+//
+// Regression test for the residue-label bug fixed in "fix: label ranked
+// residues by their own identity, not by sequence offset".
+//
+// The report templates used to name a ranked residue with
+// AA3[DATA.input.sequence[pos-1]] -- indexing the concatenated one-letter
+// sequence by residue number. That is only correct for a single chain
+// numbered 1..N with no gaps. On 3ft7 (two chains, numbered from 8) it
+// mislabelled 86 of 88 proline rows, including showing "LEU 18" with an
+// "already PRO" badge because the underlying residue really was a proline.
+//
+// Usage: node tests/verify_report_labels.js <generated-report.html> [...]
+// Exit status is non-zero if any row is mislabelled.
+//
+const fs=require('fs');
+const html=fs.readFileSync(process.argv[2],'utf8');
+const DATA=JSON.parse(html.match(/<script[^>]*id="report-data"[^>]*>([\s\S]*?)<\/script>/)[1]);
+
+// resLabel / resTag, taken verbatim from the template
+const MULTICHAIN=(DATA.input.chains||[]).length>1;
+const resTag=(chain,pos)=>MULTICHAIN?`${chain}${pos}`:`${pos}`;
+const resLabel=r=>MULTICHAIN?`${r.chain} ${r.res} ${r.pos}`:`${r.res} ${r.pos}`;
+
+let bad=0, n=0;
+for(const a of DATA.analyses){
+  for(const s of a.sites){
+    n++;
+    const label=resLabel(s);
+    // the label must name the residue the row actually is
+    if(!label.includes(s.res)||!label.includes(String(s.pos))){bad++;console.log('BAD',a.key,label,s);}
+    // already_pro must agree with the displayed name
+    if(a.key==='proline'&&s.already_pro!==(s.res==='PRO')){bad++;console.log('BADGE MISMATCH',label,s);}
+  }
+}
+
+// compact sequence: gold cysteines must land on the cysteines
+const pr=DATA.per_residue, seq=DATA.input.sequence;
+let seqBad=0;
+if(pr.length!==seq.length){console.log('LENGTH MISMATCH',pr.length,seq.length);seqBad++;}
+pr.forEach((p,k)=>{ if(p.is_cys && seq[k]!=='C'){seqBad++;console.log('CYS MISPLACED at index',k,seq[k],p);} });
+
+// what the old code would have done, for contrast
+const AA3={A:"ALA",R:"ARG",N:"ASN",D:"ASP",C:"CYS",Q:"GLN",E:"GLU",G:"GLY",H:"HIS",I:"ILE",L:"LEU",K:"LYS",M:"MET",F:"PHE",P:"PRO",S:"SER",T:"THR",W:"TRP",Y:"TYR",V:"VAL"};
+const pro=DATA.analyses.find(a=>a.key==='proline');
+let oldBad=0;
+if(pro) for(const s of pro.sites){ const disp=AA3[seq[s.pos-1]]||s.res; if(disp!==s.res) oldBad++; }
+
+const uniq=new Set((pro?pro.sites:[]).map(resLabel));
+console.log(`${process.argv[2].split('/').pop()}: chains=${DATA.input.chains.join('')} rows=${n}`);
+console.log(`  mislabeled now: ${bad}   (old sequence[pos-1] lookup would mislabel ${oldBad}/${pro?pro.sites.length:0})`);
+console.log(`  misplaced gold cysteines: ${seqBad}`);
+console.log(`  distinct proline labels: ${uniq.size}/${pro?pro.sites.length:0}`);
+process.exit(bad+seqBad?1:0);


### PR DESCRIPTION
From the BV-BRC alpha review. Independent of #22 — branched off `main`, safe to merge in either order.

## What the reviewer saw

> *"this is mapping over the words 'already Pr...' but this might be an unusually high result"*

The overlap is real. But it was sitting on top of something worse, visible in the same screenshot:

```
LYS 244  [ALREADY PR▌███████ 0.99
LYS 244  [ALREADY PR▌███████ 0.99
GLU 625  [ALREADY PR▌███████ 0.98
MET 175  [ALREADY PR▌███████ 0.98
```

A lysine cannot be already proline. And the tooltip agreed with the badge, not the name: `MET 175 / proline p = 0.98 / already proline`.

## Root cause

Both templates named a ranked residue with:

```js
AA3[DATA.input.sequence[r.pos-1]] || r.res
```

That indexes the **concatenated one-letter sequence** by **residue number**. It holds only for a single chain numbered 1..N with no gaps. Any other structure — a second chain, or numbering that doesn't start at 1 — reads a different residue entirely. `already_pro` is computed from `r.res` and stayed correct, so the badge and the name beside it disagreed.

Every row already carries its own `res`, `chain` and `pos`. The sequence lookup only ever added the bug, so `AA3` goes with it.

Reproduced on `test_data/3ft7.pdb` (chains A and B, both numbered 8–52):

```
rank chain pos  true res  displayed  already_pro
1    B     18   PRO       LEU        True    <-- MISLABELED
2    B     35   THR       LEU        False   <-- MISLABELED
3    A     30   LYS       SER        False   <-- MISLABELED
...
mislabeled in top 12: 12/12    (86 of 88 rows overall)
```

Rank 1 is really **PRO B18**, rendered as **"LEU 18 · ALREADY PRO"** — the reviewer's screenshot exactly.

`4ake_medium` masks it: a homodimer numbered 1–214 in both chains, so chain B's wrong lookup lands on the same residue type. That false negative is why this needed a structure with offset numbering to see.

## Three more of the same kind, found by sweeping for `pos`-as-index

| | |
|---|---|
| **Gold cysteines** in the compact sequence keyed off `cys_positions` (residue numbers) against a positional string — so the "SEQUENCE · CYSTEINES IN GOLD" the reviewer liked was highlighting the wrong letters. Now from `per_residue`, index-aligned by construction. |
| **Chain was dropped** from ranked rows, so a two-chain structure showed apparent duplicates at one position with different scores — the reviewer's `LYS 244` twice. Shown when there's more than one chain; the cysteine list in the metadata block is chain-qualified for the same reason (two chains can both have a CYS 40). |
| **The badge** lived inside a fixed-width label cell with `white-space:nowrap`, so it overflowed and the track painted over it. Own grid column now. |

The expanded "full sequence" view was already correct — it iterates `per_residue` with chain labels. Only the compact line was broken.

## Citation

Added to the report footer, as asked: Olson RD *et al.* **Introducing the Bacterial and Viral Bioinformatics Resource Center (BV-BRC).** *Nucleic Acids Research* 51(D1), D678–D689 (2023). Verified against the DOI, not written from memory — the docs' own `cite_patric.md` still says "NEED TO UPDATE" and gives the 2020 PATRIC reference.

## Regression test

`tests/verify_report_labels.js` asserts every ranked row is named for its own residue, that `already_pro` agrees with the displayed name, and that gold cysteines land on cysteines. It also reports what the old lookup *would* have done, so the two cases stay distinguishable:

```
3ft7  (A,B from 8): 0 mislabeled, was 86/88; 88/88 labels distinct
3pgk  (A from 1)  : 0 mislabeled, was 0/414 — no regression where the old
                    code happened to be right, and no chain prefix added
```

Both templates share this JavaScript verbatim (byte-identical `<script>` blocks); both are patched, and both pass. `node --check` clean.

## Not done

The reviewer's *"format the sequence like NCBI"* is a **Consider**, and the report already has a separate expandable per-residue view with chain labels that covers the same need. Left for a decision rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETV3Yp5n9jJjfE9bvH1CNQ
